### PR TITLE
Pass port as an environment variable for healthcheck

### DIFF
--- a/recipebuilder/recipe_builder.go
+++ b/recipebuilder/recipe_builder.go
@@ -129,8 +129,11 @@ func (b *RecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestFromCC) (*
 		monitor = &models.TimeoutAction{
 			Timeout: 30 * time.Second,
 			Action: &models.RunAction{
-				Path:      "/tmp/lifecycle/healthcheck",
-				Args:      []string{"-port=8080"},
+				Path: "/tmp/lifecycle/healthcheck",
+				Args: []string{"-port=8080"},
+				Env: []models.EnvironmentVariable{
+					models.EnvironmentVariable{Name: "PORT", Value: "8080"},
+				},
 				LogSource: HealthLogSource,
 				ResourceLimits: models.ResourceLimits{
 					Nofile: &fileDescriptorLimit,

--- a/recipebuilder/recipe_builder_test.go
+++ b/recipebuilder/recipe_builder_test.go
@@ -147,8 +147,11 @@ var _ = Describe("Recipe Builder", func() {
 			Ω(desiredLRP.Monitor).Should(Equal(&models.TimeoutAction{
 				Timeout: 30 * time.Second,
 				Action: &models.RunAction{
-					Path:      "/tmp/lifecycle/healthcheck",
-					Args:      []string{"-port=8080"},
+					Path: "/tmp/lifecycle/healthcheck",
+					Args: []string{"-port=8080"},
+					Env: []models.EnvironmentVariable{
+						models.EnvironmentVariable{Name: "PORT", Value: "8080"},
+					},
 					LogSource: "HEALTH",
 					ResourceLimits: models.ResourceLimits{
 						Nofile: &defaultNofile,
@@ -201,8 +204,11 @@ var _ = Describe("Recipe Builder", func() {
 				Ω(desiredLRP.Monitor).Should(Equal(&models.TimeoutAction{
 					Timeout: 30 * time.Second,
 					Action: &models.RunAction{
-						Path:           "/tmp/lifecycle/healthcheck",
-						Args:           []string{"-port=8080"},
+						Path: "/tmp/lifecycle/healthcheck",
+						Args: []string{"-port=8080"},
+						Env: []models.EnvironmentVariable{
+							models.EnvironmentVariable{Name: "PORT", Value: "8080"},
+						},
 						LogSource:      "HEALTH",
 						ResourceLimits: models.ResourceLimits{Nofile: &defaultNofile},
 					},


### PR DESCRIPTION
In Windows-land we do not have container ports which we can map externally, instead all ports are global to the machine. Healthcheck as it's being run via nsync uses the standard port 8080 as an argument, however GardenWindows relies on exchanging the `PORT` env var from the internal container as specified in requests, to the external port before running. For this reason we would like to have the Windows healthcheck use the `PORT` env var which GardenWindows has converted, rather than the unconverted argument.

Either me or @dgoddard are happy to answer any questions about this
