### PR TITLE
Use new routing_info field from cc_messages

### DIFF
--- a/bulk/fetcher_test.go
+++ b/bulk/fetcher_test.go
@@ -252,6 +252,18 @@ var _ = Describe("Fetcher", func() {
 			var desireRequests []cc_messages.DesireAppRequestFromCC
 
 			BeforeEach(func() {
+				routeInfo1, err := cc_messages.CCHTTPRoutes{
+					{Hostname: "route-1"},
+					{Hostname: "route-2"},
+				}.CCRouteInfo()
+				Expect(err).NotTo(HaveOccurred())
+
+				routeInfo2, err := cc_messages.CCHTTPRoutes{
+					{Hostname: "route-3"},
+					{Hostname: "route-4"},
+				}.CCRouteInfo()
+				Expect(err).NotTo(HaveOccurred())
+
 				desireRequests = []cc_messages.DesireAppRequestFromCC{
 					{
 						ProcessGuid:  "process-guid-1",
@@ -266,12 +278,9 @@ var _ = Describe("Fetcher", func() {
 						DiskMB:          1024,
 						FileDescriptors: 16,
 						NumInstances:    2,
-						Routes: []string{
-							"route-1",
-							"route-2",
-						},
-						LogGuid: "log-guid-1",
-						ETag:    "1234567.1890",
+						RoutingInfo:     routeInfo1,
+						LogGuid:         "log-guid-1",
+						ETag:            "1234567.1890",
 					},
 					{
 						ProcessGuid:  "process-guid-2",
@@ -286,12 +295,9 @@ var _ = Describe("Fetcher", func() {
 						DiskMB:          2048,
 						FileDescriptors: 32,
 						NumInstances:    4,
-						Routes: []string{
-							"route-3",
-							"route-4",
-						},
-						LogGuid: "log-guid-2",
-						ETag:    "2345678.2901",
+						RoutingInfo:     routeInfo2,
+						LogGuid:         "log-guid-2",
+						ETag:            "2345678.2901",
 					},
 					{
 						ProcessGuid:     "process-guid-3",
@@ -303,7 +309,7 @@ var _ = Describe("Fetcher", func() {
 						DiskMB:          512,
 						FileDescriptors: 8,
 						NumInstances:    4,
-						Routes:          []string{},
+						RoutingInfo:     make(cc_messages.CCRouteInfo),
 						LogGuid:         "log-guid-3",
 						ETag:            "3456789.3012",
 					},

--- a/cmd/nsync-bulker/main_test.go
+++ b/cmd/nsync-bulker/main_test.go
@@ -93,7 +93,14 @@ var _ = Describe("Syncing desired state with CC", func() {
 					"log_guid": "log-guid-1",
 					"memory_mb": 256,
 					"process_guid": "process-guid-1",
-					"routes": [ "route-1", "route-2", "new-route" ],
+					"routing_info": {
+						"http_routes":
+							[
+								{"hostname": "route-1"},
+								{"hostname": "route-2"},
+								{"hostname": "new-route"}
+							]
+					},
 					"droplet_uri": "source-url-1",
 					"stack": "some-stack",
 					"start_command": "start-command-1",
@@ -112,7 +119,12 @@ var _ = Describe("Syncing desired state with CC", func() {
 					"log_guid": "log-guid-1",
 					"memory_mb": 256,
 					"process_guid": "process-guid-2",
-					"routes": [ "route-3", "route-4" ],
+					"routing_info": {
+						"http_routes": [
+								{ "hostname": "route-3", "route_service_url":"https://rs.example.com"},
+								{ "hostname": "route-4"}
+							]
+						},
 					"droplet_uri": "source-url-1",
 					"stack": "some-stack",
 					"start_command": "start-command-1",
@@ -128,7 +140,7 @@ var _ = Describe("Syncing desired state with CC", func() {
 					"log_guid": "log-guid-3",
 					"memory_mb": 128,
 					"process_guid": "process-guid-3",
-					"routes": [],
+					"routing_info": { "http_routes": [] },
 					"droplet_uri": "source-url-3",
 					"stack": "some-stack",
 					"start_command": "start-command-3",
@@ -200,7 +212,12 @@ var _ = Describe("Syncing desired state with CC", func() {
 				"log_guid": "log-guid-1",
 				"memory_mb": 256,
 				"process_guid": "process-guid-1",
-				"routes": [ "route-1", "route-2" ],
+				"routing_info": {
+					"http_routes": [
+					{"hostname": "route-1"},
+					{"hostname": "route-2"}
+					]
+				},
 				"droplet_uri": "source-url-1",
 				"stack": "some-stack",
 				"start_command": "start-command-1",
@@ -221,7 +238,12 @@ var _ = Describe("Syncing desired state with CC", func() {
 				"log_guid": "log-guid-1",
 				"memory_mb": 256,
 				"process_guid": "process-guid-2",
-				"routes": [ "route-1", "route-2" ],
+				"routing_info": {
+					"http_routes": [
+					{"hostname": "route-1"},
+					{"hostname": "route-2"}
+					]
+				},
 				"droplet_uri": "source-url-1",
 				"stack": "some-stack",
 				"start_command": "start-command-1",

--- a/handlers/desire_app_handler.go
+++ b/handlers/desire_app_handler.go
@@ -45,6 +45,7 @@ func (h *DesireAppHandler) DesireApp(resp http.ResponseWriter, req *http.Request
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	logger.Info("request-from-cc", lager.Data{"routing_info": desiredApp.RoutingInfo})
 
 	if processGuid != desiredApp.ProcessGuid {
 		logger.Error("process-guid-mismatch", err, lager.Data{"body-process-guid": desiredApp.ProcessGuid})
@@ -120,6 +121,7 @@ func (h *DesireAppHandler) createDesiredApp(
 		return err
 	}
 
+	logger.Info("creating-desired-lrp", lager.Data{"routes": desiredLRP.Routes})
 	err = h.bbsClient.DesireLRP(desiredLRP)
 	if err != nil {
 		logger.Error("failed-to-create-lrp", err)
@@ -171,6 +173,7 @@ func (h *DesireAppHandler) updateDesiredApp(
 		Routes:     routes,
 	}
 
+	logger.Info("updating-desired-lrp", lager.Data{"routes": updateRequest.Routes})
 	err = h.bbsClient.UpdateDesiredLRP(desireAppMessage.ProcessGuid, updateRequest)
 	if err != nil {
 		logger.Error("failed-to-update-lrp", err)

--- a/handlers/desire_app_handler.go
+++ b/handlers/desire_app_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudfoundry-incubator/bbs"
 	"github.com/cloudfoundry-incubator/bbs/models"
+	"github.com/cloudfoundry-incubator/nsync/helpers"
 	"github.com/cloudfoundry-incubator/nsync/recipebuilder"
 	"github.com/cloudfoundry-incubator/route-emitter/cfroutes"
 	"github.com/cloudfoundry-incubator/runtime-schema/cc_messages"
@@ -143,9 +144,14 @@ func (h *DesireAppHandler) updateDesiredApp(
 		return err
 	}
 
-	cfRoutesJson, err := json.Marshal(cfroutes.CFRoutes{
-		{Hostnames: desireAppMessage.Routes, Port: port},
-	})
+	cfRoutes, err := helpers.CCRouteInfoToCFRoutes(desireAppMessage.RoutingInfo, port)
+	if err != nil {
+		logger.Error("failed-to-marshal-routes", err)
+		return err
+	}
+
+	cfRoutesJson, err := json.Marshal(cfRoutes)
+
 	if err != nil {
 		logger.Error("failed-to-marshal-routes", err)
 		return err

--- a/handlers/desire_app_handler_test.go
+++ b/handlers/desire_app_handler_test.go
@@ -119,6 +119,11 @@ var _ = Describe("DesireAppHandler", func() {
 			buildpackBuilder.BuildReturns(newlyDesiredLRP, nil)
 		})
 
+		It("logs the incoming and outgoing request", func() {
+			Eventually(logger.TestSink.Buffer).Should(gbytes.Say("request-from-cc"))
+			Eventually(logger.TestSink.Buffer).Should(gbytes.Say("creating-desired-lrp"))
+		})
+
 		It("creates the desired LRP", func() {
 			Expect(fakeBBS.DesireLRPCallCount()).To(Equal(1))
 
@@ -260,6 +265,11 @@ var _ = Describe("DesireAppHandler", func() {
 					"some-other-routing-data": &opaqueRoutingMessage,
 				},
 			}, nil)
+		})
+
+		It("logs the incoming and outgoing request", func() {
+			Eventually(logger.TestSink.Buffer).Should(gbytes.Say("request-from-cc"))
+			Eventually(logger.TestSink.Buffer).Should(gbytes.Say("updating-desired-lrp"))
 		})
 
 		It("checks to see if LRP already exists", func() {

--- a/helpers/helpers_suite_test.go
+++ b/helpers/helpers_suite_test.go
@@ -1,0 +1,13 @@
+package helpers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helpers Suite")
+}

--- a/helpers/routing.go
+++ b/helpers/routing.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"encoding/json"
+
+	"github.com/cloudfoundry-incubator/route-emitter/cfroutes"
+	"github.com/cloudfoundry-incubator/runtime-schema/cc_messages"
+)
+
+func CCRouteInfoToCFRoutes(ccRoutes cc_messages.CCRouteInfo, port uint32) (cfroutes.CFRoutes, error) {
+	cfRoutes := make(cfroutes.CFRoutes, 0)
+
+	if ccRoutes[cc_messages.CC_HTTP_ROUTES] != nil {
+
+		var httpRoutes cc_messages.CCHTTPRoutes
+		routeServiceMap := make(map[string][]string)
+
+		err := json.Unmarshal(*ccRoutes[cc_messages.CC_HTTP_ROUTES], &httpRoutes)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(httpRoutes) == 0 {
+			cfRoutes = append(cfRoutes, cfroutes.CFRoute{Hostnames: []string{}, Port: port})
+		}
+
+		for _, httpRoute := range httpRoutes {
+			list := routeServiceMap[httpRoute.RouteServiceUrl]
+			routeServiceMap[httpRoute.RouteServiceUrl] = append(list, httpRoute.Hostname)
+		}
+
+		for routeServiceUrl, hostnames := range routeServiceMap {
+			cfRoutes = append(cfRoutes, cfroutes.CFRoute{
+				Hostnames: hostnames, Port: port, RouteServiceUrl: routeServiceUrl,
+			})
+		}
+	} else {
+		cfRoutes = append(cfRoutes, cfroutes.CFRoute{Hostnames: []string{}, Port: port})
+	}
+
+	return cfRoutes, nil
+}

--- a/helpers/routing_test.go
+++ b/helpers/routing_test.go
@@ -1,0 +1,64 @@
+package helpers_test
+
+import (
+	"encoding/json"
+
+	"github.com/cloudfoundry-incubator/nsync/helpers"
+	"github.com/cloudfoundry-incubator/route-emitter/cfroutes"
+	"github.com/cloudfoundry-incubator/runtime-schema/cc_messages"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Routing Helpers", func() {
+	Describe("CCRouteInfo To CFRoutes", func() {
+		It("can convert itself into a CFRoutes structure", func() {
+			routeInfo, err := cc_messages.CCHTTPRoutes{
+				{Hostname: "route1"},
+				{Hostname: "route2", RouteServiceUrl: "https://rs.example.com"},
+				{Hostname: "route3"},
+			}.CCRouteInfo()
+			Expect(err).NotTo(HaveOccurred())
+
+			cfRoutes, err := helpers.CCRouteInfoToCFRoutes(routeInfo, 8080)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedRoutes := cfroutes.CFRoutes{
+				{Hostnames: []string{"route1", "route3"}, Port: 8080},
+				{Hostnames: []string{"route2"}, Port: 8080, RouteServiceUrl: "https://rs.example.com"},
+			}
+
+			Expect(cfRoutes).To(ConsistOf(expectedRoutes))
+			Expect(cfRoutes).To(HaveLen(len(expectedRoutes)))
+		})
+
+		Context("when CCRouteInfo is malformed", func() {
+			Context("when it fails to unmarshal", func() {
+				It("returns an error", func() {
+					message := json.RawMessage([]byte("some random bytes"))
+					routeInfo := map[string]*json.RawMessage{
+						cc_messages.CC_HTTP_ROUTES: &message,
+					}
+
+					_, err := helpers.CCRouteInfoToCFRoutes(routeInfo, 8080)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("when does not contain a known route type", func() {
+				It("returns an empty struct", func() {
+
+					message := json.RawMessage([]byte("some random bytes"))
+					routeInfo := map[string]*json.RawMessage{
+						"dummykey": &message,
+					}
+
+					cfRoutes, err := helpers.CCRouteInfoToCFRoutes(routeInfo, 8080)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cfRoutes).To(HaveLen(1))
+					Expect(cfRoutes[0]).To(Equal(cfroutes.CFRoute{Hostnames: []string{}, Port: 8080}))
+				})
+			})
+		})
+	})
+})

--- a/recipebuilder/buildpack_recipe_builder.go
+++ b/recipebuilder/buildpack_recipe_builder.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/cloudfoundry-incubator/bbs/models"
 	ssh_routes "github.com/cloudfoundry-incubator/diego-ssh/routes"
-	"github.com/cloudfoundry-incubator/route-emitter/cfroutes"
+	"github.com/cloudfoundry-incubator/nsync/helpers"
 	"github.com/cloudfoundry-incubator/runtime-schema/cc_messages"
 	"github.com/pivotal-golang/lager"
 )
@@ -115,9 +115,12 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 		},
 	})
 
-	desiredAppRoutingInfo := cfroutes.CFRoutes{
-		{Hostnames: desiredApp.Routes, Port: exposedPort},
-	}.RoutingInfo()
+	cfRoutes, err := helpers.CCRouteInfoToCFRoutes(desiredApp.RoutingInfo, exposedPort)
+	if err != nil {
+		buildLogger.Error("marshaling-cc-route-info-failed", err)
+		return nil, err
+	}
+	desiredAppRoutingInfo := cfRoutes.RoutingInfo()
 
 	desiredAppPorts := []uint32{exposedPort}
 

--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -51,6 +51,12 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 		config := recipebuilder.Config{lifecycles, "http://file-server.com", fakeKeyFactory}
 		builder = recipebuilder.NewBuildpackRecipeBuilder(logger, config)
 
+		routingInfo, err := cc_messages.CCHTTPRoutes{
+			{Hostname: "route1"},
+			{Hostname: "route2"},
+		}.CCRouteInfo()
+		Expect(err).NotTo(HaveOccurred())
+
 		desiredAppReq = cc_messages.DesireAppRequestFromCC{
 			ProcessGuid:       "the-app-guid-the-app-version",
 			DropletUri:        "http://the-droplet.uri.com",
@@ -64,7 +70,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 			DiskMB:          512,
 			FileDescriptors: 32,
 			NumInstances:    23,
-			Routes:          []string{"route1", "route2"},
+			RoutingInfo:     routingInfo,
 			LogGuid:         "the-log-id",
 
 			HealthCheckType:             cc_messages.PortHealthCheckType,
@@ -198,6 +204,31 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 			}))
 
 			Expect(desiredLRP.EgressRules).To(ConsistOf(egressRules))
+		})
+
+		Context("when route service url is specified in RoutingInfo", func() {
+			BeforeEach(func() {
+				routingInfo, err := cc_messages.CCHTTPRoutes{
+					{Hostname: "route1"},
+					{Hostname: "route2", RouteServiceUrl: "https://rs.example.com"},
+				}.CCRouteInfo()
+				Expect(err).NotTo(HaveOccurred())
+				desiredAppReq.RoutingInfo = routingInfo
+			})
+
+			It("sets up routes with the route service url", func() {
+				routes := *desiredLRP.Routes
+				cfRoutesJson := routes[cfroutes.CF_ROUTER]
+				cfRoutes := cfroutes.CFRoutes{}
+
+				err := json.Unmarshal(*cfRoutesJson, &cfRoutes)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(cfRoutes).To(ConsistOf([]cfroutes.CFRoute{
+					{Hostnames: []string{"route1"}, Port: 8080},
+					{Hostnames: []string{"route2"}, Port: 8080, RouteServiceUrl: "https://rs.example.com"},
+				}))
+			})
 		})
 
 		Context("when no health check is specified", func() {

--- a/recipebuilder/docker_recipe_builder.go
+++ b/recipebuilder/docker_recipe_builder.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cloudfoundry-incubator/bbs/models"
 	ssh_routes "github.com/cloudfoundry-incubator/diego-ssh/routes"
-	"github.com/cloudfoundry-incubator/route-emitter/cfroutes"
+	"github.com/cloudfoundry-incubator/nsync/helpers"
 	"github.com/cloudfoundry-incubator/runtime-schema/cc_messages"
 	"github.com/pivotal-golang/lager"
 )
@@ -140,9 +140,12 @@ func (b *DockerRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestFrom
 		},
 	})
 
-	desiredAppRoutingInfo := cfroutes.CFRoutes{
-		{Hostnames: desiredApp.Routes, Port: exposedPort},
-	}.RoutingInfo()
+	cfRoutes, err := helpers.CCRouteInfoToCFRoutes(desiredApp.RoutingInfo, exposedPort)
+	if err != nil {
+		buildLogger.Error("marshaling-cc-route-info-failed", err)
+		return nil, err
+	}
+	desiredAppRoutingInfo := cfRoutes.RoutingInfo()
 
 	desiredAppPorts := []uint32{exposedPort}
 


### PR DESCRIPTION
This PR changes `nsync` to use the new `routing_info` field in the request from the CC. That field is changed in [this PR on `runtime-schema`](https://github.com/cloudfoundry-incubator/runtime-schema/pull/10).

If the `routing_info` for a desiredApp has a route_service_url, that information is passed on using the [new `cfroutes.CFRoutes` model](https://github.com/cloudfoundry-incubator/route-emitter/pull/1).

@crhino && @utako 
