### PR TITLE
Use ports in desired app cc message for docker app

### DIFF
--- a/recipebuilder/docker_recipe_builder.go
+++ b/recipebuilder/docker_recipe_builder.go
@@ -102,7 +102,7 @@ func (b *DockerRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestFrom
 		User:     user,
 	})
 
-	desiredAppPorts, err := extractExposedPorts(executionMetadata, b.logger)
+	desiredAppPorts, err := b.ExtractExposedPorts(desiredApp)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,10 @@ func (b DockerRecipeBuilder) ExtractExposedPorts(desiredApp *cc_messages.DesireA
 	if err != nil {
 		return nil, err
 	}
-	return extractExposedPorts(metadata, b.logger)
+	if len(desiredApp.Ports) == 0 {
+		return extractExposedPorts(metadata, b.logger)
+	}
+	return desiredApp.Ports, nil
 }
 
 func extractExposedPorts(executionMetadata DockerExecutionMetadata, logger lager.Logger) ([]uint32, error) {

--- a/recipebuilder/docker_recipe_builder_test.go
+++ b/recipebuilder/docker_recipe_builder_test.go
@@ -506,7 +506,7 @@ var _ = Describe("Docker Recipe Builder", func() {
 				Context("with ports specified in execution metadata", func() {
 					BeforeEach(func() {
 						desiredAppReq.ExecutionMetadata = `{"ports":[
-				    {"Port":320, "Protocol": "udp"},
+					{"Port":320, "Protocol": "udp"},
 					{"Port":8081, "Protocol": "tcp"},
 					{"Port":8082, "Protocol": "tcp"}
 				]}`
@@ -548,7 +548,7 @@ var _ = Describe("Docker Recipe Builder", func() {
 				Context("with ports specified in execution metadata", func() {
 					BeforeEach(func() {
 						desiredAppReq.ExecutionMetadata = `{"ports":[
-				    {"Port":320, "Protocol": "udp"},
+					{"Port":320, "Protocol": "udp"},
 					{"Port":8081, "Protocol": "tcp"},
 					{"Port":8082, "Protocol": "tcp"}
 				]}`
@@ -570,7 +570,7 @@ var _ = Describe("Docker Recipe Builder", func() {
 		Context("when the docker image exposes several ports in its metadata", func() {
 			BeforeEach(func() {
 				desiredAppReq.ExecutionMetadata = `{"ports":[
-				    {"Port":320, "Protocol": "udp"},
+					{"Port":320, "Protocol": "udp"},
 					{"Port":8081, "Protocol": "tcp"},
 					{"Port":8082, "Protocol": "tcp"}
 				]}`

--- a/recipebuilder/docker_recipe_builder_test.go
+++ b/recipebuilder/docker_recipe_builder_test.go
@@ -493,10 +493,84 @@ var _ = Describe("Docker Recipe Builder", func() {
 			}))
 		})
 
+		Context("when ports are passed in desired app request", func() {
+			BeforeEach(func() {
+				desiredAppReq.Ports = []uint32{1456, 2345, 3456}
+			})
+
+			Context("when allow ssh is false", func() {
+				BeforeEach(func() {
+					desiredAppReq.AllowSSH = false
+				})
+
+				Context("with ports specified in execution metadata", func() {
+					BeforeEach(func() {
+						desiredAppReq.ExecutionMetadata = `{"ports":[
+				    {"Port":320, "Protocol": "udp"},
+					{"Port":8081, "Protocol": "tcp"},
+					{"Port":8082, "Protocol": "tcp"}
+				]}`
+					})
+					It("builds the desiredLRP with the ports specified in the desireAppRequest", func() {
+						Expect(desiredLRP.Ports).To(Equal([]uint32{1456, 2345, 3456}))
+					})
+				})
+
+				Context("with ports not specified in execution metadata", func() {
+					It("builds the desiredLRP with the ports specified in the desireAppRequest", func() {
+						Expect(desiredLRP.Ports).To(Equal([]uint32{1456, 2345, 3456}))
+					})
+				})
+
+			})
+
+			Context("when allow ssh is true", func() {
+				BeforeEach(func() {
+					desiredAppReq.AllowSSH = true
+					keyPairChan := make(chan keys.KeyPair, 2)
+
+					fakeHostKeyPair := &fake_keys.FakeKeyPair{}
+					fakeHostKeyPair.PEMEncodedPrivateKeyReturns("pem-host-private-key")
+					fakeHostKeyPair.FingerprintReturns("host-fingerprint")
+
+					fakeUserKeyPair := &fake_keys.FakeKeyPair{}
+					fakeUserKeyPair.AuthorizedKeyReturns("authorized-user-key")
+					fakeUserKeyPair.PEMEncodedPrivateKeyReturns("pem-user-private-key")
+
+					keyPairChan <- fakeHostKeyPair
+					keyPairChan <- fakeUserKeyPair
+
+					fakeKeyFactory.NewKeyPairStub = func(bits int) (keys.KeyPair, error) {
+						return <-keyPairChan, nil
+					}
+				})
+
+				Context("with ports specified in execution metadata", func() {
+					BeforeEach(func() {
+						desiredAppReq.ExecutionMetadata = `{"ports":[
+				    {"Port":320, "Protocol": "udp"},
+					{"Port":8081, "Protocol": "tcp"},
+					{"Port":8082, "Protocol": "tcp"}
+				]}`
+					})
+
+					It("builds the desiredLRP with the ports specified in the desireAppRequest", func() {
+						Expect(desiredLRP.Ports).To(Equal([]uint32{1456, 2345, 3456, 2222}))
+					})
+				})
+
+				Context("with ports not specified in execution metadata", func() {
+					It("builds the desiredLRP with the ports specified in the desireAppRequest", func() {
+						Expect(desiredLRP.Ports).To(Equal([]uint32{1456, 2345, 3456, 2222}))
+					})
+				})
+			})
+		})
+
 		Context("when the docker image exposes several ports in its metadata", func() {
 			BeforeEach(func() {
 				desiredAppReq.ExecutionMetadata = `{"ports":[
-				  {"Port":320, "Protocol": "udp"},
+				    {"Port":320, "Protocol": "udp"},
 					{"Port":8081, "Protocol": "tcp"},
 					{"Port":8082, "Protocol": "tcp"}
 				]}`
@@ -556,6 +630,15 @@ var _ = Describe("Docker Recipe Builder", func() {
 					Name:  "PORT",
 					Value: "8081",
 				}))
+			})
+
+			Context("when ports in desired app request is empty slice", func() {
+				BeforeEach(func() {
+					desiredAppReq.Ports = []uint32{}
+				})
+				It("exposes all encountered tcp ports", func() {
+					Expect(desiredLRP.Ports).To(Equal([]uint32{8081, 8082}))
+				})
 			})
 		})
 


### PR DESCRIPTION
This PR is to allow docker recipe builder to use ports specified in desire app message from cc. If no ports are specified in desire app message from cc then it continues to extract ports from execution metadata.

This is done because we need to return the ports opened for docker app as part of GET /v2/apps/:guid call in CC. Since CC already has execution_metadata, it can parse it and determine the ports to be opened for docker app. Letting CC figuring out ports for app will allow us to control the limit on number of ports in one place for both buildpack apps as well as docker apps.

Link to pivotal tracker story: https://www.pivotaltracker.com/story/show/108391924

Regards,
@atulkc and @jeffpak93 
(CF Routing team and CAPI team)
