### PR TITLE
Replace single quote with double for sshd args

### DIFF
--- a/recipebuilder/buildpack_recipe_builder.go
+++ b/recipebuilder/buildpack_recipe_builder.go
@@ -125,7 +125,7 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 			return nil, err
 		}
 
-		command := fmt.Sprintf("/tmp/lifecycle/diego-sshd -address=0.0.0.0:%d -hostKey='%s' -authorizedKey='%s' -inheritDaemonEnv -logLevel=fatal",
+		command := fmt.Sprintf(`/tmp/lifecycle/diego-sshd -address=0.0.0.0:%d -hostKey="%s" -authorizedKey="%s" -inheritDaemonEnv -logLevel=fatal`,
 			DefaultSSHPort,
 			hostKeyPair.PEMEncodedPrivateKey(),
 			userKeyPair.AuthorizedKey(),

--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 							Path: "/tmp/lifecycle/launcher",
 							Args: []string{
 								"app",
-								"/tmp/lifecycle/diego-sshd -address=0.0.0.0:2222 -hostKey='pem-host-private-key\nwith-lines' -authorizedKey='authorized-user-key' -inheritDaemonEnv -logLevel=fatal",
+								"/tmp/lifecycle/diego-sshd -address=0.0.0.0:2222 -hostKey=\"pem-host-private-key\nwith-lines\" -authorizedKey=\"authorized-user-key\" -inheritDaemonEnv -logLevel=fatal",
 								"the-execution-metadata",
 							},
 							Env: []*models.EnvironmentVariable{


### PR DESCRIPTION
Single quotes are not supported for flag arguments on Windows.

Signed-off-by: Matthew Horan mhoran@pivotal.io
