### PR TITLE
Dont populate cf-routes if CC does not send routes

### DIFF
--- a/helpers/routing.go
+++ b/helpers/routing.go
@@ -40,14 +40,6 @@ func CCRouteInfoToRoutes(ccRoutes cc_messages.CCRouteInfo, ports []uint32) (mode
 		routes[tcp_routes.TCP_ROUTER] = tcpRoutingInfo[tcp_routes.TCP_ROUTER]
 	}
 
-	if len(routes) == 0 {
-		cfRoutes := cfroutes.CFRoutes{
-			{Hostnames: []string{}, Port: defaultPort},
-		}
-		httpRoutingInfo := cfRoutes.RoutingInfo()
-		routes[cfroutes.CF_ROUTER] = httpRoutingInfo[cfroutes.CF_ROUTER]
-	}
-
 	return routes, nil
 }
 

--- a/helpers/routing_test.go
+++ b/helpers/routing_test.go
@@ -106,25 +106,16 @@ var _ = Describe("Routing Helpers", func() {
 			})
 
 			Context("when http routes do not contain any routes", func() {
-				It("returns an empty struct", func() {
-
-					message := json.RawMessage([]byte("[]"))
-					routeInfo := map[string]*json.RawMessage{
-						cc_messages.CC_HTTP_ROUTES: &message,
-					}
-
-					routes, err := helpers.CCRouteInfoToRoutes(routeInfo, []uint32{8080})
+				It("returns an empty route list", func() {
+					routeInfo := map[string]*json.RawMessage{}
+					routes, err := helpers.CCRouteInfoToRoutes(routeInfo, []uint32{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(routes).To(HaveLen(1))
-					expectedCfRoutes := cfroutes.CFRoutes{
-						cfroutes.CFRoute{Hostnames: []string{}, Port: 8080},
-					}
-					test_helpers.VerifyHttpRoutes(routes, expectedCfRoutes)
+					Expect(routes).To(HaveLen(0))
 				})
 			})
 
 			Context("when does not contain a known route type", func() {
-				It("returns an empty struct", func() {
+				It("returns an empty route list", func() {
 
 					message := json.RawMessage([]byte("some random bytes"))
 					routeInfo := map[string]*json.RawMessage{
@@ -133,11 +124,7 @@ var _ = Describe("Routing Helpers", func() {
 
 					routes, err := helpers.CCRouteInfoToRoutes(routeInfo, []uint32{8080})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(routes).To(HaveLen(1))
-					expectedCfRoutes := cfroutes.CFRoutes{
-						cfroutes.CFRoute{Hostnames: []string{}, Port: 8080},
-					}
-					test_helpers.VerifyHttpRoutes(routes, expectedCfRoutes)
+					Expect(routes).To(HaveLen(0))
 				})
 			})
 		})


### PR DESCRIPTION
This PR fixes a bug when a user deletes a route mapping, it updates the existing LRP's route to have a default port of 8080 and an empty hostname.
- Don't send empty CF-Route to Diego if CC does not provide an http route.  

Tracker story:
https://www.pivotaltracker.com/story/show/112640495

@leochu and @shashwathi
CF Routing Team
