### PR TITLE
Use env vars for keys passed to diego-sshd

### DIFF
--- a/recipebuilder/buildpack_recipe_builder.go
+++ b/recipebuilder/buildpack_recipe_builder.go
@@ -209,18 +209,18 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 			buildLogger.Error("new-user-key-pair-failed", err)
 			return nil, err
 		}
-
+		envVars := createLrpEnv(desiredApp.Environment, desiredAppPorts)
+		envVars = append(envVars, &models.EnvironmentVariable{Name: "SSHD_HOSTKEY", Value: hostKeyPair.PEMEncodedPrivateKey()})
+		envVars = append(envVars, &models.EnvironmentVariable{Name: "SSHD_AUTHKEY", Value: userKeyPair.AuthorizedKey()})
 		actions = append(actions, &models.RunAction{
 			User: "vcap",
 			Path: "/tmp/lifecycle/diego-sshd",
 			Args: []string{
 				"-address=" + fmt.Sprintf("0.0.0.0:%d", DefaultSSHPort),
-				"-hostKey=" + hostKeyPair.PEMEncodedPrivateKey(),
-				"-authorizedKey=" + userKeyPair.AuthorizedKey(),
 				"-inheritDaemonEnv",
 				"-logLevel=fatal",
 			},
-			Env: createLrpEnv(desiredApp.Environment, desiredAppPorts),
+			Env: envVars,
 			ResourceLimits: &models.ResourceLimits{
 				Nofile: &numFiles,
 			},

--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -398,14 +398,14 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 							Path: "/tmp/lifecycle/diego-sshd",
 							Args: []string{
 								"-address=0.0.0.0:2222",
-								"-hostKey=pem-host-private-key",
-								"-authorizedKey=authorized-user-key",
 								"-inheritDaemonEnv",
 								"-logLevel=fatal",
 							},
 							Env: []*models.EnvironmentVariable{
 								{Name: "foo", Value: "bar"},
 								{Name: "PORT", Value: "8080"},
+								{Name: "SSHD_HOSTKEY", Value: "pem-host-private-key"},
+								{Name: "SSHD_AUTHKEY", Value: "authorized-user-key"},
 							},
 							ResourceLimits: &models.ResourceLimits{
 								Nofile: &expectedNumFiles,

--- a/recipebuilder/docker_recipe_builder.go
+++ b/recipebuilder/docker_recipe_builder.go
@@ -206,17 +206,18 @@ func (b *DockerRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestFrom
 			return nil, err
 		}
 
+		envVars := createLrpEnv(desiredApp.Environment, desiredAppPorts)
+		envVars = append(envVars, &models.EnvironmentVariable{Name: "SSHD_HOSTKEY", Value: hostKeyPair.PEMEncodedPrivateKey()})
+		envVars = append(envVars, &models.EnvironmentVariable{Name: "SSHD_AUTHKEY", Value: userKeyPair.AuthorizedKey()})
 		actions = append(actions, &models.RunAction{
 			User: user,
 			Path: "/tmp/lifecycle/diego-sshd",
 			Args: []string{
 				"-address=" + fmt.Sprintf("0.0.0.0:%d", DefaultSSHPort),
-				"-hostKey=" + hostKeyPair.PEMEncodedPrivateKey(),
-				"-authorizedKey=" + userKeyPair.AuthorizedKey(),
 				"-inheritDaemonEnv",
 				"-logLevel=fatal",
 			},
-			Env: createLrpEnv(desiredApp.Environment, desiredAppPorts),
+			Env: envVars,
 			ResourceLimits: &models.ResourceLimits{
 				Nofile: &numFiles,
 			},

--- a/recipebuilder/docker_recipe_builder_test.go
+++ b/recipebuilder/docker_recipe_builder_test.go
@@ -396,14 +396,14 @@ var _ = Describe("Docker Recipe Builder", func() {
 							Path: "/tmp/lifecycle/diego-sshd",
 							Args: []string{
 								"-address=0.0.0.0:2222",
-								"-hostKey=pem-host-private-key",
-								"-authorizedKey=authorized-user-key",
 								"-inheritDaemonEnv",
 								"-logLevel=fatal",
 							},
 							Env: []*models.EnvironmentVariable{
 								{Name: "foo", Value: "bar"},
 								{Name: "PORT", Value: "8080"},
+								{Name: "SSHD_HOSTKEY", Value: "pem-host-private-key"},
+								{Name: "SSHD_AUTHKEY", Value: "authorized-user-key"},
 							},
 							ResourceLimits: &models.ResourceLimits{
 								Nofile: &expectedNumFiles,


### PR DESCRIPTION
For diego story https://www.pivotaltracker.com/story/show/120860423

We changed to use environment variables instead of parameters.  This then makes it much harder to find the key values inside the cell.
