### PR TITLE
fix convertVolumeMounts method in buildpack_recipe_builder 

### DIFF
--- a/recipebuilder/buildpack_recipe_builder.go
+++ b/recipebuilder/buildpack_recipe_builder.go
@@ -297,9 +297,13 @@ func convertVolumeMounts(mounts []*cc_messages.VolumeMount) []*models.VolumeMoun
 
 		// switch mount.DeviceType {
 		// case "shared":
+		mountConfig := []byte("")
+		if len(mount.Device.MountConfig) > 0 {
+			mountConfig, _ = json.Marshal(mount.Device.MountConfig)
+		}
 		bbsMount.Shared = &models.SharedDevice{
-			VolumeId:    mount.Device["volume_id"],
-			MountConfig: mount.Device["mount_config"],
+			VolumeId:    mount.Device.VolumeId,
+			MountConfig: string(mountConfig),
 		}
 		// other device types pending...
 		// }

--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 			ContainerDir: "/Volumes/myvol",
 			Mode:         "rw",
 			DeviceType:   "shared",
-			Device:       map[string]string{"volume_id": "volumeId", "mount_config": `{"key": "value"}`},
+			Device:       cc_messages.SharedDevice{VolumeId: "volumeId", MountConfig: map[string]interface{}{"key": "value"}},
 		}}
 
 		expectedBBSVolumeMounts = []*models.VolumeMount{{
@@ -121,7 +121,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 			Mode:         "rw",
 			Shared: &models.SharedDevice{
 				VolumeId:    "volumeId",
-				MountConfig: `{"key": "value"}`,
+				MountConfig: `{"key":"value"}`,
 			}},
 		}
 	})

--- a/recipebuilder/docker_recipe_builder_test.go
+++ b/recipebuilder/docker_recipe_builder_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Docker Recipe Builder", func() {
 			ContainerDir: "/Volumes/myvol",
 			Mode:         "rw",
 			DeviceType:   "shared",
-			Device:       map[string]string{"volume_id": "volumeId", "mount_config": `{"key": "value"}`},
+			Device:       cc_messages.SharedDevice{VolumeId: "volumeId", MountConfig: map[string]interface{}{"key": "value"}},
 		}}
 
 		expectedBBSVolumeMounts = []*models.VolumeMount{{
@@ -80,7 +80,7 @@ var _ = Describe("Docker Recipe Builder", func() {
 			Mode:         "rw",
 			Shared: &models.SharedDevice{
 				VolumeId:    "volumeId",
-				MountConfig: `{"key": "value"}`,
+				MountConfig: `{"key":"value"}`,
 			}},
 		}
 	})


### PR DESCRIPTION
...to expect mount_config as an object (not a string)

[#119780891](https://www.pivotaltracker.com/story/show/119780891)

In our previous pull request we managed to get the conversion code in NSYNC a little bit incorrect, and treated volume_mount.device.mount_config as a string.  This means that if someone were to follow [the 2.10 docs](https://docs.cloudfoundry.org/services/volume-services-v2.10.html) their apps would fail to start after binding to volume services.

**NOTE:** You will also need to pull [this pull request for runtimeschema](https://github.com/cloudfoundry/runtimeschema/pull/12)

![obligatory animal photo](http://icycute.com/media/cutepix/cutest_lemur_ever.jpg)
