### PR TITLE
Integrate with Diego for Isolation Segments

### DIFF
--- a/recipebuilder/buildpack_recipe_builder.go
+++ b/recipebuilder/buildpack_recipe_builder.go
@@ -81,6 +81,12 @@ func (b *BuildpackRecipeBuilder) BuildTask(task *cc_messages.TaskRequestFromCC) 
 
 	rootFSPath := models.PreloadedRootFS(task.RootFs)
 
+	placementTags := []string{}
+
+	if task.IsolationSegment != "" {
+		placementTags = []string{task.IsolationSegment}
+	}
+
 	taskDefinition := &models.TaskDefinition{
 		Privileged:            b.config.PrivilegedContainers,
 		LogGuid:               task.LogGuid,
@@ -100,6 +106,7 @@ func (b *BuildpackRecipeBuilder) BuildTask(task *cc_messages.TaskRequestFromCC) 
 		TrustedSystemCertificatesPath: TrustedSystemCertificatesPath,
 		LogSource:                     task.LogSource,
 		VolumeMounts:                  convertVolumeMounts(task.VolumeMounts),
+		PlacementTags:                 placementTags,
 	}
 
 	return taskDefinition, nil
@@ -245,6 +252,12 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 	setupAction := models.Serial(setup...)
 	actionAction := models.Codependent(actions...)
 
+	placementTags := []string{}
+
+	if desiredApp.IsolationSegment != "" {
+		placementTags = []string{desiredApp.IsolationSegment}
+	}
+
 	return &models.DesiredLRP{
 		Privileged: b.config.PrivilegedContainers,
 
@@ -283,6 +296,7 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 
 		TrustedSystemCertificatesPath: TrustedSystemCertificatesPath,
 		VolumeMounts:                  convertVolumeMounts(desiredApp.VolumeMounts),
+		PlacementTags:                 placementTags,
 	}, nil
 }
 

--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -212,6 +212,8 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 				)
 				Expect(desiredLRP.Setup.GetValue()).To(Equal(expectedSetup))
 
+				Expect(desiredLRP.PlacementTags).To(BeEmpty())
+
 				expectedCacheDependencies := []*models.CachedDependency{
 					&models.CachedDependency{
 						From:     "http://file-server.com/v1/static/some-lifecycle.tgz",
@@ -528,6 +530,16 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 					})
 				})
 			})
+
+			Context("when an IsolationSegment is specified", func() {
+				BeforeEach(func() {
+					desiredAppReq.IsolationSegment = "foo"
+				})
+
+				It("includes the the correct segment in the desiredLRP", func() {
+					Expect(desiredLRP.PlacementTags).To(ContainElement("foo"))
+				})
+			})
 		})
 
 		Context("when there is a docker image url AND a droplet uri", func() {
@@ -791,6 +803,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 			Expect(taskDefinition.EgressRules).To(ConsistOf(egressRules))
 			Expect(taskDefinition.TrustedSystemCertificatesPath).To(Equal(recipebuilder.TrustedSystemCertificatesPath))
 			Expect(taskDefinition.LogSource).To(Equal("APP/TASK/my-task"))
+			Expect(taskDefinition.PlacementTags).To(BeEmpty())
 
 			expectedAction := models.Serial(&models.DownloadAction{
 				From:              newTaskReq.DropletUri,
@@ -840,6 +853,16 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 
 			It("returns an error", func() {
 				Expect(err).To(Equal(recipebuilder.ErrMultipleAppSources))
+			})
+		})
+
+		Context("when the isolation segment is specified", func() {
+			BeforeEach(func() {
+				newTaskReq.IsolationSegment = "foo"
+			})
+
+			It("includes the correct isolation segment in the placement tags", func() {
+				Expect(taskDefinition.PlacementTags).To(ContainElement("foo"))
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: Dan Lavine <dlavine@us.ibm.com>

Enable integration with diego by processing the IS label/name in desiredLRP messages.  This PR depends on [this PR to runtimeschema](https://github.com/cloudfoundry/runtimeschema/pull/13) and should really be done in conjunction with [this PR to stager](https://github.com/cloudfoundry/stager/pull/14).