### PR TITLE
Restore VCAP_APP_PORT for build pack applications

### DIFF
--- a/recipebuilder/buildpack_recipe_builder.go
+++ b/recipebuilder/buildpack_recipe_builder.go
@@ -193,7 +193,7 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 			desiredApp.StartCommand,
 			desiredApp.ExecutionMetadata,
 		),
-		Env:       createLrpEnv(desiredApp.Environment, desiredAppPorts),
+		Env:       createLrpEnv(desiredApp.Environment, desiredAppPorts, true),
 		LogSource: getAppLogSource(desiredApp.LogSource),
 		ResourceLimits: &models.ResourceLimits{
 			Nofile: &numFiles,
@@ -229,7 +229,7 @@ func (b *BuildpackRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestF
 				"-inheritDaemonEnv",
 				"-logLevel=fatal",
 			},
-			Env: createLrpEnv(desiredApp.Environment, desiredAppPorts),
+			Env: createLrpEnv(desiredApp.Environment, desiredAppPorts, true),
 			ResourceLimits: &models.ResourceLimits{
 				Nofile: &numFiles,
 			},

--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -169,6 +169,15 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 
 				Expect(varNames).NotTo(ContainElement("PORT"))
 			})
+
+			It("does not include a VCAP_APP_PORT environment variable", func() {
+				varNames := []string{}
+				for _, envVar := range desiredLRP.EnvironmentVariables {
+					varNames = append(varNames, envVar.Name)
+				}
+
+				Expect(varNames).NotTo(ContainElement("VCAP_APP_PORT"))
+			})
 		})
 
 		Context("when everything is correct", func() {
@@ -270,6 +279,11 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 
 				Expect(runAction.Env).To(ContainElement(&models.EnvironmentVariable{
 					Name:  "PORT",
+					Value: "8080",
+				}))
+
+				Expect(runAction.Env).To(ContainElement(&models.EnvironmentVariable{
+					Name:  "VCAP_APP_PORT",
 					Value: "8080",
 				}))
 
@@ -440,6 +454,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 							Env: []*models.EnvironmentVariable{
 								{Name: "foo", Value: "bar"},
 								{Name: "PORT", Value: "8080"},
+								{Name: "VCAP_APP_PORT", Value: "8080"},
 							},
 							ResourceLimits: &models.ResourceLimits{
 								Nofile: &expectedNumFiles,
@@ -459,6 +474,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 							Env: []*models.EnvironmentVariable{
 								{Name: "foo", Value: "bar"},
 								{Name: "PORT", Value: "8080"},
+								{Name: "VCAP_APP_PORT", Value: "8080"},
 							},
 							ResourceLimits: &models.ResourceLimits{
 								Nofile: &expectedNumFiles,

--- a/recipebuilder/docker_recipe_builder.go
+++ b/recipebuilder/docker_recipe_builder.go
@@ -188,7 +188,7 @@ func (b *DockerRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestFrom
 			desiredApp.StartCommand,
 			desiredApp.ExecutionMetadata,
 		),
-		Env:       createLrpEnv(desiredApp.Environment, desiredAppPorts),
+		Env:       createLrpEnv(desiredApp.Environment, desiredAppPorts, false),
 		LogSource: getAppLogSource(desiredApp.LogSource),
 		ResourceLimits: &models.ResourceLimits{
 			Nofile: &numFiles,
@@ -224,7 +224,7 @@ func (b *DockerRecipeBuilder) Build(desiredApp *cc_messages.DesireAppRequestFrom
 				"-inheritDaemonEnv",
 				"-logLevel=fatal",
 			},
-			Env: createLrpEnv(desiredApp.Environment, desiredAppPorts),
+			Env: createLrpEnv(desiredApp.Environment, desiredAppPorts, false),
 			ResourceLimits: &models.ResourceLimits{
 				Nofile: &numFiles,
 			},

--- a/recipebuilder/docker_recipe_builder_test.go
+++ b/recipebuilder/docker_recipe_builder_test.go
@@ -273,6 +273,11 @@ var _ = Describe("Docker Recipe Builder", func() {
 					Value: "8080",
 				}))
 
+				Expect(runAction.Env).NotTo(ContainElement(&models.EnvironmentVariable{
+					Name:  "VCAP_APP_PORT",
+					Value: "8080",
+				}))
+
 				Expect(desiredLRP.EgressRules).To(ConsistOf(egressRules))
 
 				Expect(desiredLRP.TrustedSystemCertificatesPath).To(Equal(recipebuilder.TrustedSystemCertificatesPath))

--- a/recipebuilder/recipe_builder.go
+++ b/recipebuilder/recipe_builder.go
@@ -78,9 +78,13 @@ func cpuWeight(memoryMB int) uint32 {
 	return uint32((100 * cpuProxy) / MaxCpuProxy)
 }
 
-func createLrpEnv(env []*models.EnvironmentVariable, exposedPorts []uint32) []*models.EnvironmentVariable {
+func createLrpEnv(env []*models.EnvironmentVariable, exposedPorts []uint32, includeDeprecated bool) []*models.EnvironmentVariable {
 	if len(exposedPorts) > 0 {
-		env = append(env, &models.EnvironmentVariable{Name: "PORT", Value: fmt.Sprintf("%d", exposedPorts[0])})
+		portValue := fmt.Sprintf("%d", exposedPorts[0])
+		env = append(env, &models.EnvironmentVariable{Name: "PORT", Value: portValue})
+		if includeDeprecated {
+			env = append(env, &models.EnvironmentVariable{Name: "VCAP_APP_PORT", Value: portValue})
+		}
 	}
 	return env
 }


### PR DESCRIPTION
During the migration from DEA to Diego, we found a number of node.js applications failed to start on Diego. It turns out that most of them are using VCAP_APP_PORT to discover the port to listen on.

This change will populate VCAP_APP_PORT in build pack applications but won't propagate it to docker apps. 