### PR TITLE
Restore VCAP_APP_HOST environment variable

### DIFF
--- a/recipebuilder/buildpack_recipe_builder_test.go
+++ b/recipebuilder/buildpack_recipe_builder_test.go
@@ -287,6 +287,11 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 					Value: "8080",
 				}))
 
+				Expect(runAction.Env).To(ContainElement(&models.EnvironmentVariable{
+					Name:  "VCAP_APP_HOST",
+					Value: "0.0.0.0",
+				}))
+
 				Expect(desiredLRP.EgressRules).To(ConsistOf(egressRules))
 
 				Expect(desiredLRP.TrustedSystemCertificatesPath).To(Equal(recipebuilder.TrustedSystemCertificatesPath))
@@ -455,6 +460,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 								{Name: "foo", Value: "bar"},
 								{Name: "PORT", Value: "8080"},
 								{Name: "VCAP_APP_PORT", Value: "8080"},
+								{Name: "VCAP_APP_HOST", Value: "0.0.0.0"},
 							},
 							ResourceLimits: &models.ResourceLimits{
 								Nofile: &expectedNumFiles,
@@ -475,6 +481,7 @@ var _ = Describe("Buildpack Recipe Builder", func() {
 								{Name: "foo", Value: "bar"},
 								{Name: "PORT", Value: "8080"},
 								{Name: "VCAP_APP_PORT", Value: "8080"},
+								{Name: "VCAP_APP_HOST", Value: "0.0.0.0"},
 							},
 							ResourceLimits: &models.ResourceLimits{
 								Nofile: &expectedNumFiles,

--- a/recipebuilder/docker_recipe_builder_test.go
+++ b/recipebuilder/docker_recipe_builder_test.go
@@ -278,6 +278,11 @@ var _ = Describe("Docker Recipe Builder", func() {
 					Value: "8080",
 				}))
 
+				Expect(runAction.Env).NotTo(ContainElement(&models.EnvironmentVariable{
+					Name:  "VCAP_APP_HOST",
+					Value: "0.0.0.0",
+				}))
+
 				Expect(desiredLRP.EgressRules).To(ConsistOf(egressRules))
 
 				Expect(desiredLRP.TrustedSystemCertificatesPath).To(Equal(recipebuilder.TrustedSystemCertificatesPath))

--- a/recipebuilder/recipe_builder.go
+++ b/recipebuilder/recipe_builder.go
@@ -86,6 +86,11 @@ func createLrpEnv(env []*models.EnvironmentVariable, exposedPorts []uint32, incl
 			env = append(env, &models.EnvironmentVariable{Name: "VCAP_APP_PORT", Value: portValue})
 		}
 	}
+
+	if includeDeprecated {
+		env = append(env, &models.EnvironmentVariable{Name: "VCAP_APP_HOST", Value: "0.0.0.0"})
+	}
+
 	return env
 }
 


### PR DESCRIPTION
Signed-off-by: Dan Lavine <dlavine@us.ibm.com>

This restores the setting of the VCAP_APP_HOST environment variable using the same behavior as was present when using the DEAs.  I will do a separate PR to add this logic to the bridge-cc-merge codebase as well.